### PR TITLE
Upgrade Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN choco install -y git
 RUN choco install -y mingw
 
 ENV GOPATH C:\gopath
-RUN git clone -q --branch=v%DOCKER_VERSION% https://github.com/docker/cli.git C:\gopath\src\github.com\docker\cli
+RUN git clone -q --branch=v%DOCKER_VERSION% --single-branch https://github.com/docker/cli.git C:\gopath\src\github.com\docker\cli
 WORKDIR C:\gopath\src\github.com\docker\cli
 COPY setversion.ps1 setversion.ps1
 RUN powershell -File .\setversion.ps1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # escape=`
 FROM microsoft/windowsservercore
 
-ENV GOVERSION 1.10.3
+ENV GOVERSION 1.10.8
 ENV DEPVERSION v0.4.1
-ENV DOCKER_VERSION 18.09.0
+ENV DOCKER_VERSION 18.09.6
 
 ENV chocolateyUseWindowsCompression false
 RUN powershell iex(iwr -useb https://chocolatey.org/install.ps1)
@@ -13,9 +13,8 @@ RUN choco install -y git
 RUN choco install -y mingw
 
 ENV GOPATH C:\gopath
-RUN git clone -q --branch=master https://github.com/docker/cli.git C:\gopath\src\github.com\docker\cli
+RUN git clone -q --branch=v%DOCKER_VERSION% https://github.com/docker/cli.git C:\gopath\src\github.com\docker\cli
 WORKDIR C:\gopath\src\github.com\docker\cli
-RUN git checkout v%DOCKER_VERSION%
 COPY setversion.ps1 setversion.ps1
 RUN powershell -File .\setversion.ps1
 RUN type C:\gopath\src\github.com\docker\cli\cli\version.go


### PR DESCRIPTION
Instead of checking out master and then changing branch, we can just checkout what we need, should save some time with the build.

Also, this change enabled us to build each minor release, as the binary only seems to get built for the first release at the moment

I also think its worth looking into how we can build multiple versions, so you can also provide the betas of future versions