### PR TITLE
Bump docker to 19.03.6 and go to 1.13.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # escape=`
 FROM microsoft/windowsservercore
 
-ENV GOVERSION 1.12.10
+ENV GOVERSION 1.13.8
 ENV DEPVERSION v0.4.1
-ENV DOCKER_VERSION 19.03.3
+ENV DOCKER_VERSION 19.03.6
 
 ENV chocolateyUseWindowsCompression false
 RUN powershell iex(iwr -useb https://chocolatey.org/install.ps1)


### PR DESCRIPTION
Per https://github.com/docker/cli/releases/tag/v19.03.6 and https://chocolatey.org/packages/golang