### PR TITLE
Bump Docker version to 19.03.14 and Go version to 1.13.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # escape=`
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
-ENV GOVERSION 1.13.12
+ENV GOVERSION 1.13.15
 ENV DEPVERSION v0.4.1
-ENV DOCKER_VERSION 19.03.12
+ENV DOCKER_VERSION 19.03.14
 
 ENV chocolateyUseWindowsCompression false
 RUN powershell iex(iwr -useb https://chocolatey.org/install.ps1)


### PR DESCRIPTION
Looking at https://github.com/docker/cli/tree/v19.03.14, this should be the right versions